### PR TITLE
feat: add new assigner modes and update documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,41 +1,59 @@
 # CHANGELOG
 
+## 0.0.11 (20251217)
+
+### Features
+
+- Add new Assigner Modes: `auto_readonly` and `manual_readonly`, allowing assigned fields to be locked in the UI after assignment.
+
+### Breaking
+
+- Remove Assigner mode `auto_force`; `auto` is now defined as auto-trigger on dependency change with force overwrite.
+
 ## 0.0.10 (20251202)
 
 ### Features
+
 - Rename `airalogy.aimd` module to `airalogy.markdown` for better clarity
 - Add `get_airalogy_image_ids` API for `airalogy.markdown`
 
 ## 0.0.9 (20251120)
 
 ### Features
+
 - Add Typed AIMD variable syntax support
 - Add command-line interface (CLI) with syntax checking and model generation commands
 - Add Chinese demographic enum types for enhanced data modeling
 - Support standalone assigner functions with simplified decorator syntax
 
 ### Documentation
+
 - Add typed AIMD variable syntax documentation
 - Simplify Assigner syntax documentation by removing class-based definitions
 
 ### Development
+
 - New parser implementation
 
 ## 0.0.8 (20251029)
 
 ### Features
+
 - Add `CurrentProtocolId` and `CurrentRecordId` types
 
 ### Development
+
 - Migrate from pdm to uv
 - Update minimum Python version requirement to 3.13
 - Add GitHub workflow for CI
 - Add build status badge
 
 ### Dependencies
+
 - Update pydantic dependency from 2.11.5 to 2.12.3
 
 ### Fixes
+
 - Fix description
 
 ## 0.0.7 (20250827)

--- a/docs/en/syntax/assigner.md
+++ b/docs/en/syntax/assigner.md
@@ -45,8 +45,7 @@ from airalogy.assigner import AssignerResult, assigner
 @assigner(
     assigned_fields=["var_3"],  # fields to assign
     dependent_fields=["var_1", "var_2"],  # fields that this function depends on
-    mode="auto",  # "auto" = run whenever dependencies change
-                  # "manual" = user must click "Assign" button in the UI
+    mode="auto",  # See "Assigner Modes" below
 )
 def calculate_var_3(dependent_fields: dict) -> AssignerResult:
     v1 = dependent_fields["var_1"]
@@ -61,13 +60,23 @@ def calculate_var_3(dependent_fields: dict) -> AssignerResult:
 > **Many-to-many is allowed**
 > An Assigner can read *any* number of fields and assign *any* number of fields—across `var`, `step`, and `check` alike.
 
-## 2 `dependent_fields` and `assigned_fields`
+## 2 Assigner Modes
+
+The `mode` affects **when** the Assigner is triggered, and whether it is expected to be **user-editable** after assignment.
+
+- `"auto"`: run whenever dependencies change, and **overwrite** the assigned field value with the new result.
+- `"manual"`: do **not** auto-run; user must click an "Assign" button in the UI. Use this if you don't want auto-trigger on every dependency change.
+- `"auto_first"`: run automatically **once** (typically when dependencies become available), then stop auto-refresh; behavior-wise you can think of it as “auto once, then like `manual` (needs a manual trigger to run again)”.
+- `"auto_readonly"`: same as `"auto"`, but UI should lock assigned fields after filling.
+- `"manual_readonly"`: same as `"manual"`, but UI should lock assigned fields after filling.
+
+## 3 `dependent_fields` and `assigned_fields`
 
 - Both are plain Python **dicts** whose keys are field names.
 - Values follow the JSON Schema of the protocol; i.e. only JSON-serialisable types.
 - For special field classes (e.g. a checkpoint) you may need to wrap the value in a helper model such as `CheckValue`.
 
-## 3 Working with Complex Types
+## 4 Working with Complex Types
 
 If a field stores a complex type (e.g. `datetime`) it is transmitted as a JSON-compatible value (usually a string).
 Convert it to a native Python object before calculation, then convert back:
@@ -95,7 +104,7 @@ def plus_one_day(dep: dict) -> AssignerResult:
     )
 ```
 
-## 4 Assigners for Checkpoints
+## 5 Assigners for Checkpoints
 
 Checkpoints (`check`) can be calculated the same way, but you must return a `CheckValue`:
 
@@ -133,7 +142,7 @@ def check_sum(dep: dict) -> AssignerResult:
 | - | - |
 | `assigned_fields` | List of field names the function assigns |
 | `dependent_fields` | List of field names the function depends on |
-| `mode` | `"auto"` (run on change) or `"manual"` (run on button click) |
+| `mode` | `"auto"` (run on change + overwrite), `"manual"` (button click), `"auto_first"` (run once), `"auto_readonly"` (auto + lock), or `"manual_readonly"` (manual + lock) |
 
 ### `AssignerResult`
 

--- a/docs/zh/syntax/assigner.md
+++ b/docs/zh/syntax/assigner.md
@@ -52,10 +52,7 @@ from airalogy.assigner import (
         "var_1",
         "var_2",
     ],
-    mode="auto", # 用于定义Assigner的模式。
-    # 不同模式的含义如下：
-    # "auto": 自动计算的赋值单元，即只要其依赖的Fields的值发生变化，该Assigner就会自动执行，以更新其赋值的Fields的值
-    # "manual": 手动计算的赋值单元，即需要用户手动点击前端的赋值按钮来执行
+    mode="auto", # 用于定义Assigner的模式（见下文“Assigner模式”小节）
 )
 def calculate_var_3(dependent_fields: dict) -> AssignerResult: # 赋值函数的函数名可以任意命名，但其接收的参数必须为`dependent_fields`，且返回值必须为一个AssignerResult对象。其中`dependent_fields`字典必须包含所有依赖的Fields的值（即`dependent_fields`中的key-value对应于Fields的名称和值，且必须一一对应）
     var_1_value = dependent_fields["var_1"] # 从`dependent_fields`字典中取出`var_1`的值
@@ -88,6 +85,16 @@ return AssignerResult(
     },
 )
 ```
+
+## Assigner模式
+
+`mode` 会影响 Assigner 的**触发时机**，以及被赋值 Fields 在赋值后是否应允许用户继续编辑（由前端/执行器实现交互策略）。
+
+- `"auto"`：当依赖字段发生变化时自动触发，并**强制覆写**被赋值 Fields 的当前值。
+- `"manual"`：不自动触发；需要用户在前端点击“Assign/赋值”按钮才执行。如果不希望依赖字段每次变化都触发，建议使用该模式。
+- `"auto_first"`：自动触发**一次**（通常是依赖字段首次齐备时），之后不再自动刷新；触发行为上可理解为“先自动执行一次，后续等价于 `manual`（需要手动触发才会再次执行）”。
+- `"auto_readonly"`：与 `"auto"` 相同，但一旦赋值后前端应禁止用户手动修改被赋值 Fields。
+- `"manual_readonly"`：与 `"manual"` 相同，但一旦赋值后前端应禁止用户手动修改被赋值 Fields。
 
 ### `dependent_fields`/`assigned_fields`的数据结构
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airalogy"
-version = "0.0.10"
+version = "0.0.11"
 description = "The world's first universal framework for standardized data digitization"
 readme = "README.md"
 authors = [{ name = "Airalogy Team" }]

--- a/src/airalogy/__init__.py
+++ b/src/airalogy/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.10"
+__version__ = "0.0.11"
 
 from airalogy.airalogy import Airalogy
 from . import markdown

--- a/src/airalogy/assigner/assigner_base.py
+++ b/src/airalogy/assigner/assigner_base.py
@@ -19,7 +19,17 @@ def unique_list(lst):
     return list(set(lst))
 
 
-AssignerMode = Literal["manual", "auto_first", "auto", "auto_force"]
+AssignerMode = Literal[
+    "manual",
+    "manual_readonly",
+    "auto_first",
+    "auto",
+    "auto_readonly",
+]
+
+
+def is_manual_assigner(mode: AssignerMode) -> bool:
+    return mode in ("manual", "manual_readonly")
 
 
 def _is_function_defined_in_class(func: Callable) -> bool:
@@ -55,7 +65,7 @@ class AssignerBase:
                 raise ValueError(
                     f"assigned_fields must be not empty when using {assign_func.__name__}."
                 )
-            if len(dependent_fields) == 0 and mode != "manual":
+            if len(dependent_fields) == 0 and not is_manual_assigner(mode):
                 raise ValueError(
                     f"dependent_fields must be not empty when using {assign_func.__name__} in mode {mode}."
                 )
@@ -166,7 +176,7 @@ class AssignerBase:
             return []
 
     @classmethod
-    def all_assigned_fields(cls) -> dict[str, list[str]]:
+    def all_assigned_fields(cls) -> dict[str, dict[str, object]]:
         return {
             k: {
                 "dependent_fields": cls.get_dependent_fields_of_assigned_key(k),

--- a/tests/test_assigner.py
+++ b/tests/test_assigner.py
@@ -71,7 +71,7 @@ class RvAssigner(AssignerBase):
             "rv_04",
             "rv_06",
         ],
-        mode="auto_force",
+        mode="auto",
     )
     def assign_rv07(dependent_fields: dict) -> AssignerResult:
         rv_07 = dependent_fields["rv_04"] + dependent_fields["rv_07"]
@@ -198,7 +198,7 @@ def test_all_assigned_fields():
         "rv_05",
         "rv_06",
     ]
-    assert rfs["rv_07"]["mode"] == "auto_force"
+    assert rfs["rv_07"]["mode"] == "auto"
 
 
 def test_rv_assigner():
@@ -333,3 +333,31 @@ def test_standalone_manual_assigner():
 
     assert result.success
     assert result.assigned_fields == {"standalone_rv_net": 17}
+
+
+class ReadonlyRvAssigner(AssignerBase):
+    @assigner(
+        assigned_fields=["rv_readonly_auto"],
+        dependent_fields=["rv_01"],
+        mode="auto_readonly",
+    )
+    def assign_readonly_auto(dependent_fields: dict) -> AssignerResult:
+        return AssignerResult(
+            assigned_fields={"rv_readonly_auto": dependent_fields["rv_01"]}
+        )
+
+    @assigner(
+        assigned_fields=["rv_readonly_manual"],
+        dependent_fields=[],
+        mode="manual_readonly",
+    )
+    def assign_readonly_manual(_dependent_fields: dict) -> AssignerResult:
+        return AssignerResult(assigned_fields={"rv_readonly_manual": 1})
+
+
+def test_readonly_modes_exposed_in_all_assigned_fields():
+    rfs = ReadonlyRvAssigner.all_assigned_fields()
+
+    assert rfs["rv_readonly_auto"]["mode"] == "auto_readonly"
+
+    assert rfs["rv_readonly_manual"]["mode"] == "manual_readonly"


### PR DESCRIPTION
## 0.0.11 (20251217)

### Features

- Add new Assigner Modes: `auto_readonly` and `manual_readonly`, allowing assigned fields to be locked in the UI after assignment.

### Breaking

- Remove Assigner mode `auto_force`; `auto` is now defined as auto-trigger on dependency change with force overwrite.
